### PR TITLE
Packages that work on Ubuntu 22.04

### DIFF
--- a/docs/docs/Development-Environment-Guide.md
+++ b/docs/docs/Development-Environment-Guide.md
@@ -46,7 +46,7 @@ end integration testing.
 
 - Open a terminal and run `sudo apt update`
 
-- Run `sudo apt install gnupg2 unzip xz-utils cmake make g++ libgtest-dev mediainfo libssl-dev liblog4cxx-dev libboost-dev file openjdk-17-jdk python3.8-dev python3-pip python3.8-venv libde265-dev libopenblas-dev liblapacke-dev libavcodec-dev libavcodec-extra libavformat-dev libavutil-dev libswscale-dev libavresample-dev libharfbuzz-dev libfreetype-dev ffmpeg git git-lfs redis postgresql-12 curl ansible`
+- Run `sudo apt install gnupg2 unzip xz-utils cmake make g++ libgtest-dev mediainfo libssl-dev liblog4cxx-dev libboost-dev file openjdk-17-jdk python3.11-dev python3-pip python3.11-venv libde265-dev libopenblas-dev liblapacke-dev libavcodec-dev libavcodec-extra libavformat-dev libavutil-dev libswscale-dev libswresample-dev libharfbuzz-dev libfreetype-dev ffmpeg git git-lfs redis postgresql-14 curl`
 
 - Run `sudo ln --symbolic /usr/include/x86_64-linux-gnu/openblas-pthread/cblas.h /usr/include/cblas.h`
 


### PR DESCRIPTION
Issue:

- Running Ubuntu 22.04 as a dev environment runs into a few issues with dependency packages missing.

Solution:

- This PR aims to resolve the deps needed to setup dev environment.
- Interestingly, libavresample was substituted with libswresample: https://github.com/home-assistant/developers.home-assistant/issues/1353

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf.github.io/196)
<!-- Reviewable:end -->
